### PR TITLE
Use availableProcessors() worker threads

### DIFF
--- a/benchmarks/src/main/scala/fs2/netty/benchmarks/echo/RawNetty.scala
+++ b/benchmarks/src/main/scala/fs2/netty/benchmarks/echo/RawNetty.scala
@@ -17,7 +17,8 @@
 package fs2.netty.benchmarks.echo
 
 import io.netty.bootstrap.ServerBootstrap
-import io.netty.channel.{ChannelFuture, ChannelHandlerContext, ChannelInitializer, ChannelInboundHandlerAdapter, ChannelOption}
+import io.netty.channel.epoll.{Epoll, EpollEventLoopGroup, EpollServerSocketChannel}
+import io.netty.channel.{ChannelFuture, ChannelHandlerContext, ChannelInboundHandlerAdapter, ChannelInitializer, ChannelOption}
 import io.netty.channel.nio.NioEventLoopGroup
 import io.netty.channel.socket.nio.NioServerSocketChannel
 import io.netty.channel.socket.SocketChannel
@@ -29,13 +30,23 @@ object RawNetty {
     val host = args(0)
     val port = args(1).toInt
 
-    val parent = new NioEventLoopGroup(1)
-    val child = new NioEventLoopGroup(1)
+    val (parent, child, channelClass) = if (Epoll.isAvailable) {
+      println("Using epoll")
+      (new EpollEventLoopGroup(1),
+        new EpollEventLoopGroup(Runtime.getRuntime.availableProcessors()),
+        classOf[EpollServerSocketChannel]
+      )
+    } else {
+      println("Using NIO")
+      (new NioEventLoopGroup(1),
+        new NioEventLoopGroup(Runtime.getRuntime.availableProcessors()),
+        classOf[NioServerSocketChannel])
+    }
 
     val bootstrap = new ServerBootstrap
     bootstrap.group(parent, child)
       .option(ChannelOption.AUTO_READ.asInstanceOf[ChannelOption[Any]], false)
-      .channel(classOf[NioServerSocketChannel])
+      .channel(channelClass)
       .childHandler(new ChannelInitializer[SocketChannel] {
         def initChannel(ch: SocketChannel) = {
           ch.config().setAutoRead(false)


### PR DESCRIPTION
Basic RPS benchmark results from Ryzen 5900X:

This branch:
Fs2Netty: 305456 request/sec, 305456 response/sec

main:
Fs2Netty: 149224 request/sec, 149224 response/sec
Fs2IO: 160947 request/sec, 160947 response/sec
RawNetty: 302905 request/sec, 302905 response/sec

Closes #4 